### PR TITLE
Release new flathub maintenance version

### DIFF
--- a/gtkmm.json
+++ b/gtkmm.json
@@ -2,9 +2,9 @@
     "name": "gtkmm",
     "sources": [
         {
-            "sha256": "9beb71c3e90cfcfb790396b51e3f5e7169966751efd4f3ef9697114be3be6743",
+            "sha256": "30d5bfe404571ce566a8e938c8bac17576420eb508f1e257837da63f14ad44ce",
             "type": "archive",
-            "url": "https://ftp.gnome.org/pub/GNOME/sources/gtkmm/3.24/gtkmm-3.24.4.tar.xz"
+            "url": "https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.9.tar.xz"
         }
     ],
     "buildsystem": "meson",
@@ -28,9 +28,9 @@
             "name": "mm-common",
             "sources": [
                 {
-                    "sha256": "a2a99f3fa943cf662f189163ed39a2cfc19a428d906dd4f92b387d3659d1641d",
+                    "sha256": "b55c46037dbcdabc5cee3b389ea11cc3910adb68ebe883e9477847aa660862e7",
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.2.tar.xz"
+                    "url": "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.6.tar.xz"
                 }
             ],
             "cleanup": [
@@ -45,9 +45,9 @@
             "name": "sigc++",
             "sources": [
                 {
-                    "sha256": "dda176dc4681bda9d5a2ac1bc55273bdd381662b7a6d49e918267d13e8774e1b",
+                    "sha256": "235a40bec7346c7b82b6a8caae0456353dc06e71f14bc414bcc858af1838719a",
                     "type": "archive",
-                    "url": "https://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.10/libsigc++-2.10.6.tar.xz"
+                    "url": "https://download.gnome.org/sources/libsigc++/2.10/libsigc++-2.10.8.tar.xz"
                 }
             ],
             "config-opts": [
@@ -64,9 +64,9 @@
             "name": "glibmm",
             "sources": [
                 {
-                    "sha256": "9e1db7d43d2e2d4dfa2771354e21a69a6beec7c446b711619cf8c779e13a581e",
+                    "sha256": "fe02c1e5f5825940d82b56b6ec31a12c06c05c1583cfe62f934d0763e1e542b3",
                     "type": "archive",
-                    "url": "https://ftp.gnome.org/pub/GNOME/sources/glibmm/2.66/glibmm-2.66.0.tar.xz"
+                    "url": "https://download.gnome.org/sources/glibmm/2.66/glibmm-2.66.7.tar.xz"
                 }
             ],
             "buildsystem": "meson",
@@ -88,9 +88,9 @@
             "name": "cairomm",
             "sources": [
                 {
-                    "sha256": "0126b9cc295dc36bc9c0860d5b720cb5469fd78d5620c8f10cc5f0c07b928de3",
+                    "sha256": "70136203540c884e89ce1c9edfb6369b9953937f6cd596d97c78c9758a5d48db",
                     "type": "archive",
-                    "url": "https://www.cairographics.org/releases/cairomm-1.14.2.tar.xz"
+                    "url": "https://www.cairographics.org/releases/cairomm-1.14.5.tar.xz"
                 }
             ],
             "config-opts": [
@@ -118,8 +118,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ftp.gnome.org/pub/GNOME/sources/pangomm/2.46/pangomm-2.46.3.tar.xz",
-                    "sha256": "410fe04d471a608f3f0273d3a17d840241d911ed0ff2c758a9859c66c6f24379"
+                    "url": "https://download.gnome.org/sources/pangomm/2.46/pangomm-2.46.4.tar.xz",
+                    "sha256": "b92016661526424de4b9377f1512f59781f41fb16c9c0267d6133ba1cd68db22"
                 }
             ]
         },
@@ -127,9 +127,9 @@
             "name": "atkmm",
             "sources": [
                 {
-                    "sha256": "116876604770641a450e39c1f50302884848ce9cc48d43c5dc8e8efc31f31bad",
+                    "sha256": "0a142a8128f83c001efb8014ee463e9a766054ef84686af953135e04d28fdab3",
                     "type": "archive",
-                    "url": "https://ftp.gnome.org/pub/GNOME/sources/atkmm/2.28/atkmm-2.28.1.tar.xz"
+                    "url": "https://download.gnome.org/sources/atkmm/2.28/atkmm-2.28.4.tar.xz"
                 }
             ],
             "buildsystem": "meson",

--- a/net.sourceforge.pdfchain.json
+++ b/net.sourceforge.pdfchain.json
@@ -99,6 +99,10 @@
                     "path": "patches/pdfchain-icon-path.patch"
                 },
                 {
+                    "type": "patch",
+                    "path": "patches/fix_app_crash_with_gcc13.patch"
+                },
+                {
                     "type": "file",
                     "path": "net.sourceforge.pdfchain.metainfo.xml"
                 }

--- a/net.sourceforge.pdfchain.json
+++ b/net.sourceforge.pdfchain.json
@@ -1,7 +1,7 @@
 {
     "app-id": "net.sourceforge.pdfchain",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "22.08",
+    "runtime-version": "24.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "pdfchain",
     "rename-desktop-file": "pdfchain.desktop",
@@ -16,11 +16,11 @@
         "--persist=.java",
         "--filesystem=xdg-documents",
         "--filesystem=xdg-download",
-        "--filesystem=xdg-pictures",
         "--filesystem=/run/media",
         "--filesystem=/media",
         "--share=ipc",
-        "--socket=x11",
+        "--socket=fallback-x11",
+        "--socket=wayland",
         "--device=dri"
     ],
     "cleanup": [
@@ -68,8 +68,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://gitlab.com/pdftk-java/pdftk/-/jobs/924565145/artifacts/raw/build/libs/pdftk-all.jar",
-                    "sha256": "3e0b7f6d159f1bed2ad485d583b0a903f9b1167ad67fb7edafd398a6e337d51c",
+                    "url": "https://gitlab.com/api/v4/projects/5024297/packages/generic/pdftk-java/v3.3.3/pdftk-all.jar",
+                    "sha256": "a694d49bd03e1edd4c23b3ba808bc221eb8a8ccfe7bfd2a0a884b2b2fb425188",
                     "dest-filename": "pdftk-all.jar"
                 },
                 {

--- a/net.sourceforge.pdfchain.metainfo.xml
+++ b/net.sourceforge.pdfchain.metainfo.xml
@@ -6,7 +6,7 @@
   <project_license>GPL-3.0</project_license>
   <developer_name>Martin Singer</developer_name>
   <name>PDF Chain</name>
-  <summary>PDF Chain is a graphical user interface for the PDF Toolkit (PDFtk)</summary>
+  <summary>Graphical interface for the PDF Toolkit (PDFtk)</summary>
   <description>
   <p>If PDF is electronic paper, then PDFtk is an electronic staple-remover,
     hole-punch, binder, secret-decoder-ring, and X-Ray-glasses. PDFtk is a
@@ -33,7 +33,7 @@
   <p>Latest version of this software is very old and so it may contain bugs,
      so to be on the safe side make sure to NOT open any untrusted pdf files
      with it. For this same reason we have limited this application to only
-     save files to standard locations: "Downloads", "Documents" and "Pictures".
+     save files to standard locations: "Downloads", "Documents".
      You can also save to external devices (like USB pendrive).
   </p>
   </description>
@@ -43,28 +43,28 @@
   </provides>
   <screenshots>
     <screenshot>
-    <image type="source">https://a.fsdn.com/con/app/proj/pdfchain/screenshots/329661.jpg/max/max/1</image>
-    <caption>Concatenate extended</caption>
+    <image type="source">https://github.com/user-attachments/assets/0dc05a9c-0c18-4570-86b0-f631205857a6</image>
+    <caption>Combines selected pages of various documents into a single output document</caption>
     </screenshot>
     <screenshot>
-    <image type="source">https://a.fsdn.com/con/app/proj/pdfchain/screenshots/329663.jpg/max/max/1</image>
-    <caption>Burst</caption>
+    <image type="source">https://github.com/user-attachments/assets/11ce5bf0-f5e5-403f-9314-82e1ed15a2b1</image>
+    <caption>Splits a single document into individual pages</caption>
     </screenshot>
     <screenshot>
-    <image type="source">https://a.fsdn.com/con/app/proj/pdfchain/screenshots/329673.jpg/max/max/1</image>
-    <caption>Tools</caption>
+    <image type="source">https://github.com/user-attachments/assets/3d703fb8-7878-4ad7-9ce9-d075ec65ba98</image>
+    <caption>Prints a background or a stamp layer on each page of a single document</caption>
     </screenshot>
     <screenshot type="default">
-    <image type="source">https://a.fsdn.com/con/app/proj/pdfchain/screenshots/329659.jpg/max/max/1</image>
-    <caption>Concatenate simple</caption>
+    <image type="source">https://github.com/user-attachments/assets/34310b3d-8dd2-49bf-be94-e6625b363de4</image>
+    <caption>Attaches several files to a single document</caption>
     </screenshot>
     <screenshot>
-    <image type="source">https://a.fsdn.com/con/app/proj/pdfchain/screenshots/329671.jpg/max/max/1</image>
-    <caption>Background / Stamp</caption>
+    <image type="source">https://github.com/user-attachments/assets/2862e599-5b14-49ed-acdf-639fa25c0fcf</image>
+    <caption>Some different tools to work with a single document</caption>
     </screenshot>
     <screenshot>
-    <image type="source">https://a.fsdn.com/con/app/proj/pdfchain/screenshots/329669.jpg/max/max/1</image>
-    <caption>Attachment</caption>
+    <image type="source">https://github.com/user-attachments/assets/487f0528-2306-4071-b828-e60a2c796df8</image>
+    <caption>Shows About dialog in dark theme</caption>
     </screenshot>
   </screenshots>
   <url type="homepage">https://sourceforge.net/projects/pdfchain/</url>

--- a/net.sourceforge.pdfchain.metainfo.xml
+++ b/net.sourceforge.pdfchain.metainfo.xml
@@ -71,6 +71,21 @@
   <update_contact>nbenitezl_AT_gmail.com</update_contact>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="0.4.4.2.fl1" date="2024-11-23">
+    <description>
+      <p>0.4.4.2-fl1 flathub maintenance release</p>
+      <ul>
+        <li>Fix app crashing when built with GCC >= 13.1</li>
+        <li>Update runtime to Freedesktop 24.08</li>
+        <li>Update gtkmm.json versions</li>
+        <li>Remove "Pictures" folder permission</li>
+        <li>Add wayland socket pemission</li>
+        <li>Re-phrase metainfo file Summary according to guidelines</li>
+        <li>Update screenshots</li>
+      </ul>
+    </description>
+    <url>https://sourceforge.net/projects/pdfchain/files/pdfchain-0.4.4.2/</url>
+    </release>
     <release version="0.4.4.2" date="2015-12-18">
     <description>
       <p>0.4.4.2 release</p>

--- a/patches/fix_app_crash_with_gcc13.patch
+++ b/patches/fix_app_crash_with_gcc13.patch
@@ -1,0 +1,94 @@
+--- pdfchain-code/src/window_main_bgst.cc	2017-03-13 09:02:38.000000000 +0000
++++ pdfchain-code/src/window_main_bgst.cc	2024-11-23 16:47:51.367501743 +0000
+@@ -37,7 +37,7 @@
+ 	mLabel_SourceFile( _("Document:")    , Gtk::ALIGN_END , Gtk::ALIGN_CENTER , false ) ,	// label , xalign , yalign , mnemonic
+ 	mLabel_BgStFile(   _("Layer (PDF):") , Gtk::ALIGN_END , Gtk::ALIGN_CENTER , false ) ,
+ 
+-	mRBGroup_BgSt( mRButton_Background.get_group() ) ,
++	mRBGroup_BgSt() ,
+ 	mRButton_Background(	mRBGroup_BgSt , _("Background")	, false ) ,	// group , label , mnemonic
+ 	mRButton_Stamp(			mRBGroup_BgSt , _("Stamp")		, false ) ,
+ 
+--- pdfchain-code/src/window_main_bgst.h	2017-03-13 09:02:38.000000000 +0000
++++ pdfchain-code/src/window_main_bgst.h	2024-11-23 16:47:46.138502053 +0000
+@@ -64,12 +64,13 @@
+ 		Gtk::CheckButton
+ 			mCButton_Multiple;
+ 
+-		Gtk::RadioButton			// Declaration of Gtk::RadioButton before Gtk::RadioButtonGroup!!!
++		Gtk::RadioButtonGroup		// Declaration of Gtk::RadioButtonGroup before Gtk::RadioButton!!!
++			mRBGroup_BgSt;
++
++		Gtk::RadioButton			// Declaration of Gtk::RadioButton behind Gtk::RadioButtonGroup!!!
+ 			mRButton_Background ,
+ 			mRButton_Stamp;
+ 
+-		Gtk::RadioButtonGroup		// Declaration of Gtk::RadioButtonGroup behind Gtk::RadioButton!!!
+-			mRBGroup_BgSt;
+ 
+ 		// Derived Widgets
+ 		cFCButton_Pdf
+--- pdfchain-code/src/window_main_burst.cc	2017-03-13 09:02:38.000000000 +0000
++++ pdfchain-code/src/window_main_burst.cc	2024-11-23 16:12:48.654626359 +0000
+@@ -62,7 +62,7 @@
+ 	mLabel_Digits(     _("Digits:")   , Gtk::ALIGN_END , Gtk::ALIGN_CENTER , false ),
+ 	mLabel_Suffix(     _("Suffix:")   , Gtk::ALIGN_END , Gtk::ALIGN_CENTER , false ),
+ 
+-	mRBGroup_CounterDigits( mRButton_Auto.get_group() ),
++	mRBGroup_CounterDigits(),
+ 	mRButton_Auto(   mRBGroup_CounterDigits , _("Auto")	   , false ),	// group , label , mnemonic
+ 	mRButton_Manual( mRBGroup_CounterDigits , _("Manual:") , false ),
+ 
+--- pdfchain-code/src/window_main_burst.h	2017-03-13 09:02:38.000000000 +0000
++++ pdfchain-code/src/window_main_burst.h	2024-11-23 16:13:59.653622151 +0000
+@@ -118,13 +118,13 @@
+ 		Gtk::SpinButton					// Declaration of Gtk::SpinButton behind Glib::RefPtr<Gtk::Adjustment>!!!
+ 			mSButton_Digits;
+ 
+-		Gtk::RadioButton				// Declaration of Gtk::RadioButton before Gtk::RadioButtonGroup!!!
++		Gtk::RadioButtonGroup			// Declaration of Gtk::RadioButtonGroup before Gtk::RadioButton!!!
++			mRBGroup_CounterDigits;
++
++		Gtk::RadioButton				// Declaration of Gtk::RadioButton behind Gtk::RadioButtonGroup!!!
+ 			mRButton_Auto ,
+ 		    mRButton_Manual;
+ 
+-		Gtk::RadioButtonGroup			// Declaration of Gtk::RadioButtonGroup behind Gtk::RadioButton!!!
+-			mRBGroup_CounterDigits;
+-
+ 		Gtk::CheckButton
+ 			mCButton_Extension;
+ 
+--- pdfchain-code/src/window_main_tool.cc	2017-03-13 09:02:38.000000000 +0000
++++ pdfchain-code/src/window_main_tool.cc	2024-11-23 16:44:18.454514361 +0000
+@@ -50,7 +50,7 @@
+ mCButton_FillForm_Flatten(    _("Flatten")          , false ),
+ mCButton_FillForm_Appearance( _("Need appearances") , false ),
+ 
+-mRBGroup_Tool( mRButton_UnpackFiles.get_group() ),
++mRBGroup_Tool(),
+ 
+ mRButton_Repair(         mRBGroup_Tool , _("Repair docu_ment")                     , true ),	// group , label , mnemonic
+ mRButton_UnpackFiles(    mRBGroup_Tool , _("Un_pack attached files from document") , true ),
+--- pdfchain-code/src/window_main_tool.h	2017-03-13 09:02:38.000000000 +0000
++++ pdfchain-code/src/window_main_tool.h	2024-11-23 16:44:16.038514504 +0000
+@@ -57,6 +57,9 @@
+ 			mLabel_DumpDataFile ,
+ 			mLabel_FdfFile;
+ 
++		Gtk::RadioButtonGroup
++			mRBGroup_Tool;
++
+ 		Gtk::RadioButton
+ 			mRButton_Repair ,
+ 			mRButton_UnpackFiles ,
+@@ -71,9 +74,6 @@
+ 			mRButton_Flatten ,
+ 			mRButton_DropXfa;
+ 
+-		Gtk::RadioButtonGroup
+-			mRBGroup_Tool;
+-
+ 		Gtk::CheckButton
+ 			mCButton_DumpDataFields_Utf8 ,
+ 			mCButton_DumpData_Utf8 ,


### PR DESCRIPTION
 - Fix app crashing if built with GCC >= 13.1 
 - Update runtime to 24.08 and deps to latest versions
 - Update gtkmm.json versions
 - Remove "Pictures" folder permission
 - Add wayland socket pemission
 - Re-phrase metainfo file Summary according to guidelines
 - Update screenshots to improve them and also fix this [flathub page issue](https://github.com/flathub-infra/website/issues/4192)  


<summary>Fix app crashing if built with GCC >= 13.1</summary>
<details>

App worked fine in runtime 22.08 (GCC 12.2.0)
but starting crashing with runtime 23.08 which
comes with GCC 13.1.0

After debugging the crash, the problem was the
order in which the class member initializers were
executed (more info [here](https://stackoverflow.com/a/1828058)) because the code
had some classes initializing `Gtk::RadioButton`
members with a reference to a `Gtk::RadioButtonGroup`
that was still not initialized, because that
`Gtk::RadioButtonGroup` member was declared in the
header file after the `Gtk::RadioButton` in question.

Apparently GCC 12 was more resilient to this kind
of inconsistency.
</details>